### PR TITLE
Keep record key when transforming data

### DIFF
--- a/src/main/java/org/radarbase/kafka/connect/transforms/KeyValueTransform.java
+++ b/src/main/java/org/radarbase/kafka/connect/transforms/KeyValueTransform.java
@@ -60,7 +60,7 @@ public class KeyValueTransform<R extends ConnectRecord<R>> implements Transforma
     newData = addValuesToNewSchema(newData, recordValue, r.valueSchema());
     newData.put(TIMESTAMP_FIELD, r.timestamp());
 
-    return r.newRecord(r.topic(), r.kafkaPartition(), null, null, schema, newData, r.timestamp());
+    return r.newRecord(r.topic(), r.kafkaPartition(), r.keySchema(), r.key(), schema, newData, r.timestamp());
   }
 
   private Struct addValuesToNewSchema(Struct newData, Struct oldData, Schema oldSchema){
@@ -86,9 +86,9 @@ public class KeyValueTransform<R extends ConnectRecord<R>> implements Transforma
     return schemaBuilder;
   }
 
-  private R applySchemaless(R record) {
-    Map<String, Object> value = requireMap(record.value(), PURPOSE);
-    Map<String, Object> key = requireMap(record.key(), PURPOSE);
+  private R applySchemaless(R r) {
+    Map<String, Object> value = requireMap(r.value(), PURPOSE);
+    Map<String, Object> key = requireMap(r.key(), PURPOSE);
     Map<String, Object> newData = new HashMap<>();
     for (Map.Entry<String, Object> entry : key.entrySet()) {
       newData.put(entry.getKey(), entry.getValue());
@@ -100,8 +100,9 @@ public class KeyValueTransform<R extends ConnectRecord<R>> implements Transforma
         fieldVal = convertTimestamp(fieldVal);
       newData.put(fieldName, fieldVal);
     }
-    newData.put(TIMESTAMP_FIELD, record.timestamp());
-    return record.newRecord(record.topic(), record.kafkaPartition(), null, null, null, newData, record.timestamp());
+    newData.put(TIMESTAMP_FIELD, r.timestamp());
+    
+    return r.newRecord(r.topic(), r.kafkaPartition(), null, r.key(), null, newData, r.timestamp());
   }
 
   private Object convertTimestamp(Object time){


### PR DESCRIPTION
- Keeps record key when transforming data, previously set to `null`
- Also renames `record` variable for consistency