### PR TITLE
Change record value time fields from epoch time to timestamps

### DIFF
--- a/src/main/java/org/radarbase/kafka/connect/transforms/KeyValueTransform.java
+++ b/src/main/java/org/radarbase/kafka/connect/transforms/KeyValueTransform.java
@@ -34,7 +34,6 @@ public class KeyValueTransform<R extends ConnectRecord<R>> implements Transforma
   private static final String TIMESTAMP_FIELD = "timestamp";
   private static final String KEYVALUE_SCHEMA_NAME = "KeyToValue";
   private static final Set<String> TIME_FIELDS = new HashSet<>(Arrays.asList("time", "timeReceived", "timeCompleted"));
-  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
 
   @Override
   public R apply(R r) {

--- a/src/main/java/org/radarbase/kafka/connect/transforms/KeyValueTransform.java
+++ b/src/main/java/org/radarbase/kafka/connect/transforms/KeyValueTransform.java
@@ -22,6 +22,7 @@ import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 
 import java.util.*;
+import java.util.Date;
 
 /**
  *
@@ -105,9 +106,8 @@ public class KeyValueTransform<R extends ConnectRecord<R>> implements Transforma
 
   private Object convertTimestamp(Object time){
     if (time instanceof Double) {
-      Calendar result = Calendar.getInstance(UTC);
-      result.setTimeInMillis((long) Math.round((Double) time * 1000));
-      return result.getTime();
+      Date result = new Date((long) Math.round((Double) time * 1000));
+      return result;
     } else {
       return time; // If it’s not a double, the conversion may not be correct. Skip conversion.
     }


### PR DESCRIPTION
- Change record value time fields from epoch time to timestamps to support macros (e.g. `$_timeGroup()`) in Grafana for easy aggregation of record counts (and other calculations)
